### PR TITLE
morph map support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,27 +16,31 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.2, 8.1, 8.0]
+        php: [8.3, 8.2, 8.1, 8.0]
         laravel: ['8.*', '9.*', '10.*', '11.*']
         stability: [prefer-stable]
         include:
+          - laravel: 11.*
+            testbench: 9.*
           - laravel: 10.*
             testbench: 8.*
           - laravel: 9.*
             testbench: 7.*
           - laravel: 8.*
             testbench: 6.23
-          - laravel: 11.*
-            testbench: 9.*
         exclude:
-          - laravel: 10.*
-            php: 8.0
-          - laravel: 8.*
-            php: 8.2
           - laravel: 11.*
             php: 8.1
           - laravel: 11.*
             php: 8.0
+          - laravel: 10.*
+            php: 8.0
+          - laravel: 9.*
+            php: 8.3
+          - laravel: 8.*
+            php: 8.3
+          - laravel: 8.*
+            php: 8.2
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A Laravel package to sign documents and optionally generate
 
 ## Requirements
 
-Laravel pad signature requires **PHP 8.0, 8.1 or 8.2** and **Laravel 8, 9 or 10**.
+Laravel pad signature requires **PHP 8.0, 8.1, 8.2 or 8.3** and **Laravel 8, 9, 10 or 11**.
 
 ## Installation
 
@@ -113,7 +113,7 @@ A `$model` object will be automatically injected into the Blade template, so you
 
 ## Usage
 
-At this point, all you need is to create the form with the sign pad canvas in your template. For the route of the form, you have to call the method getSignatureUrl() from the instance of the model you prepared before:
+At this point, all you need is to create the form with the sign pad canvas in your template. For the route of the form, you have to call the method getSignatureRoute() from the instance of the model you prepared before:
 
 ```html
 @if (!$myModel->hasBeenSigned())

--- a/src/Controllers/LaravelSignPadController.php
+++ b/src/Controllers/LaravelSignPadController.php
@@ -46,9 +46,7 @@ class LaravelSignPadController
 
         $uuid = Str::uuid()->toString();
         $filename = "{$uuid}.png";
-        $signature = Signature::create([
-            'model_type' => $model::class,
-            'model_id' => $model->id,
+        $signature = $model->signature()->create([
             'uuid' => $uuid,
             'from_ips' => $request->ips(),
             'filename' => $filename,

--- a/src/Controllers/LaravelSignPadController.php
+++ b/src/Controllers/LaravelSignPadController.php
@@ -40,7 +40,7 @@ class LaravelSignPadController
             abort(403, 'Invalid token');
         }
 
-        if ($model instanceof CanBeSigned and $model->hasBeenSigned()) {
+        if ($model instanceof CanBeSigned && $model->hasBeenSigned()) {
             throw new ModelHasAlreadyBeenSigned();
         }
 


### PR DESCRIPTION
Right now the package does not support the use of custom polymorphic types.
See: https://laravel.com/docs/11.x/eloquent-relationships#custom-polymorphic-types

If you use a MorphMap the morph relation can not be resolved right now.
The main reason is because you are setting `model_type` manually.
If we switch to create the morph relation via Laravel functionality, we can support both ways.
With and without MorphMap.

p.s. here benefits of morph map support: https://laravel-news.com/enforcing-morph-maps-in-laravel#content-benefits-of-morph-maps

Beside that:
- mentioned support for Laravel 11 and PHP 8.3
- added PHP 8.3 to the set of tested versions

Thank you very much for that package and the maintenance of it.
If you have any suggestions or concerns let me know.