### PR TITLE
Add dynamic redirect URL support after signature submission

### DIFF
--- a/resources/views/components/signature-pad.blade.php
+++ b/resources/views/components/signature-pad.blade.php
@@ -5,6 +5,9 @@
             class="{{ $padClasses }}"></canvas>
     <div>
         <input type="hidden" name="sign" class="sign">
+        @if($redirectUrl)
+            <input type="hidden" name="redirect_url" value="{{ $redirectUrl }}">
+        @endif
         <button type="button" class="sign-pad-button-clear {{$buttonClasses}}">{!! $clearName !!}</button>
         <button type="submit" class="sign-pad-button-submit {{$buttonClasses}}" {{ $disabledWithoutSignature ? 'disabled' : '' }}>{!! $submitName !!}</button>
     </div>

--- a/src/Components/SignaturePad.php
+++ b/src/Components/SignaturePad.php
@@ -23,6 +23,8 @@ class SignaturePad extends Component
 
     public bool $disabledWithoutSignature;
 
+    public string $redirectUrl;
+
     /**
      * Create a new component instance.
      *
@@ -36,7 +38,8 @@ class SignaturePad extends Component
         string $borderColor = '#777777',
         string $submitName = 'Submit',
         string $clearName = 'Clear',
-        bool $disabledWithoutSignature = false
+        bool $disabledWithoutSignature = false,
+        string $redirectUrl = ''
     ) {
         $this->width = $width ?? config('sign-pad.width');
         $this->height = $height ?? config('sign-pad.height');
@@ -50,6 +53,8 @@ class SignaturePad extends Component
         $this->clearName = $clearName;
 
         $this->disabledWithoutSignature = $disabledWithoutSignature;
+
+        $this->redirectUrl = $redirectUrl;
     }
 
     /**

--- a/src/Controllers/LaravelSignPadController.php
+++ b/src/Controllers/LaravelSignPadController.php
@@ -63,6 +63,6 @@ class LaravelSignPadController
             );
         }
 
-        return redirect()->route(config('sign-pad.redirect_route_name'), ['uuid' => $uuid]);
+        return back();
     }
 }

--- a/src/Controllers/LaravelSignPadController.php
+++ b/src/Controllers/LaravelSignPadController.php
@@ -63,6 +63,10 @@ class LaravelSignPadController
             );
         }
 
+        if ($request->filled('redirect_url')) {
+            return redirect()->to($request->input('redirect_url'));
+        }
+
         return back();
     }
 }

--- a/tests/Feature/SignPadComponentTest.php
+++ b/tests/Feature/SignPadComponentTest.php
@@ -8,6 +8,7 @@ it('has default component values', function () {
     $this->assertTrue($signPadComponent->submitName === 'Submit');
     $this->assertTrue($signPadComponent->clearName === 'Clear');
     $this->assertTrue($signPadComponent->borderColor === '#777777');
+    $this->assertTrue($signPadComponent->redirectUrl === '');
 });
 
 it('can override default component values', function () {
@@ -20,4 +21,13 @@ it('can override default component values', function () {
     $this->assertTrue($signPadComponent->submitName === 'Envia');
     $this->assertTrue($signPadComponent->clearName === 'Borra');
     $this->assertTrue($signPadComponent->borderColor === '#EAEAEA');
+    $this->assertTrue($signPadComponent->redirectUrl === '');
+});
+
+it('can set redirect url on component', function () {
+    $signPadComponent = new SignaturePad(
+        redirectUrl: '/custom-redirect'
+    );
+
+    $this->assertTrue($signPadComponent->redirectUrl === '/custom-redirect');
 });

--- a/tests/Feature/SignPadControllerTest.php
+++ b/tests/Feature/SignPadControllerTest.php
@@ -55,3 +55,27 @@ it('stores the signature image and deletes', function () {
     Storage::disk(config('sign-pad.disk_name'))->assertMissing($filePath);
     Storage::disk(config('sign-pad.disk_name'))->assertExists($signature2->getSignatureImagePath());
 });
+
+it('redirects back by default when redirect_url is not provided', function () {
+    Storage::fake(config('sign-pad.disk_name'));
+    $model = TestModel::create();
+    $sign = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAlgAAADICAYAAAA0n5+2AAAAAXNSR0IArs4c6QAAEG1JREFUeF7t3U2odVUZB/C/BObMV6pBkOhAjXJgIYSRYk2CBqERUY3UCo2w1EkfkzSCqElpkG';
+
+    $response = $this->from('/original-page')
+        ->post($model->getSignatureRoute(), ['sign' => $sign]);
+
+    $response->assertRedirect('/original-page');
+});
+
+it('redirects to custom url when redirect_url is provided', function () {
+    Storage::fake(config('sign-pad.disk_name'));
+    $model = TestModel::create();
+    $sign = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAlgAAADICAYAAAA0n5+2AAAAAXNSR0IArs4c6QAAEG1JREFUeF7t3U2odVUZB/C/BObMV6pBkOhAjXJgIYSRYk2CBqERUY3UCo2w1EkfkzSCqElpkG';
+
+    $response = $this->post($model->getSignatureRoute(), [
+        'sign' => $sign,
+        'redirect_url' => '/custom-dashboard',
+    ]);
+
+    $response->assertRedirect('/custom-dashboard');
+});


### PR DESCRIPTION
**Description**
Currently, the controller always redirects back to the previous page after a successful signature submission (return back()). This PR adds the ability for users to configure a custom redirect URL via the <x-laravel-sign-pad::signature-pad> Blade component.

If redirect-url is not provided, the behavior remains unchanged (back()), ensuring full backward compatibility.

**Changes**
_src/Components/SignaturePad.php_
- Added public string $redirectUrl property
- Added string $redirectUrl = '' parameter to constructor (defaults to empty string)

_resources/views/components/signature-pad.blade.php_
- Added a conditional hidden input redirect_url that is only rendered when $redirectUrl is set

_src/Controllers/LaravelSignPadController.php_
- Added redirect logic: if redirect_url is present in the request, redirect to that URL; otherwise fallback to back()

_tests/Feature/SignPadComponentTest.php_
- Added assertion for default redirectUrl value (empty string)
- Added test case for setting custom redirectUrl on component

_tests/Feature/SignPadControllerTest.php_
- Added test: redirects back by default when redirect_url is not provided
- Added test: redirects to custom URL when redirect_url is provided

**Usage**
```
{{-- Default behavior (redirects back) --}}
<x-laravel-sign-pad::signature-pad />

{{-- Custom redirect --}}
<x-laravel-sign-pad::signature-pad redirect-url="{{ route('dashboard') }}" />
<x-laravel-sign-pad::signature-pad redirect-url="/success-page" />
```